### PR TITLE
(BKR-1216) Add beaker-vmware to vcloud

### DIFF
--- a/beaker-vcloud.gemspec
+++ b/beaker-vcloud.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
   s.add_runtime_dependency 'rbvmomi', '~> 1.9'
   s.add_runtime_dependency 'beaker-vmpooler'
+  s.add_runtime_dependency 'beaker-vmware'
 
 end
 

--- a/lib/beaker/hypervisor/vcloud.rb
+++ b/lib/beaker/hypervisor/vcloud.rb
@@ -1,5 +1,6 @@
 require 'yaml' unless defined?(YAML)
 require 'beaker/hypervisor/vmpooler'
+require 'beaker/hypervisor/vsphere_helper'
 require 'rbvmomi'
 
 module Beaker


### PR DESCRIPTION
The vcloud hypervisor requires the VsphereHelper class, but that was
separated out to a separate gem during the great modularization of
2017. This PR includes the gem that contains the necessary code for
vcloud instances to be created properly.