### PR TITLE
(BKR-1217) Suppress enable_root on cygwin boxes

### DIFF
--- a/lib/beaker/hypervisor/vcloud.rb
+++ b/lib/beaker/hypervisor/vcloud.rb
@@ -180,7 +180,7 @@ module Beaker
               @vsphere_helper.find_vms(host['vmhostname'])[host['vmhostname']].summary.guest.ipAddress != nil
             end
             host[:ip] = @vsphere_helper.find_vms(host['vmhostname'])[host['vmhostname']].summary.guest.ipAddress
-            enable_root(host)
+            enable_root(host) unless host.is_cygwin?
           end
         end
 


### PR DESCRIPTION
Cygwin boxes have pre-prepped SSL keys already setup - the enable_root
method breaks these, so needs to be suppressed for cygwin hosts.