### PR TITLE
(BKR-1094) Deprecate vcloud's silent fallback to vmpooler

### DIFF
--- a/beaker-vcloud.gemspec
+++ b/beaker-vcloud.gemspec
@@ -20,7 +20,12 @@ Gem::Specification.new do |s|
   # Testing dependencies
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-its'
-  s.add_development_dependency 'fakefs', '~> 0.6'
+  # pin fakefs for Ruby < 2.3
+  if RUBY_VERSION < "2.3"
+    s.add_development_dependency 'fakefs', '~> 0.6', '< 0.14'
+  else
+    s.add_development_dependency 'fakefs', '~> 0.6'
+  end
   s.add_development_dependency 'rake', '~> 10.1'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'pry', '~> 0.10'

--- a/lib/beaker/hypervisor/vcloud.rb
+++ b/lib/beaker/hypervisor/vcloud.rb
@@ -6,16 +6,22 @@ require 'rbvmomi'
 module Beaker
   class Vcloud < Beaker::Hypervisor
 
+    def self.new(vcloud_hosts, options)
+      # Deprecation warning for pre-vmpooler style hosts configuration.
+      if options['pooling_api'] && !options['datacenter']
+        options[:logger].warn "It looks like you may be trying to access vmpooler with `hypervisor: vcloud`. "\
+                              "This functionality has been deprecated. Please transition to `hypervisor: vmpooler`."
+        Beaker::Vmpooler.new(vcloud_hosts, options)
+      else
+        super
+      end
+    end
+
+
     def initialize(vcloud_hosts, options)
       @options = options
       @logger = options[:logger]
       @hosts = vcloud_hosts
-
-      # Deprecation warning for pre-vmpooler style hosts configuration.
-      if options['pooling_api'] && !options['datacenter']
-        @logger.warn "It looks like you may be trying to access vmpooler with `hypervisor: vcloud`."
-        @logger.warn "This functionality has been deprecated. Please use `hypervisor: vmpooler`."
-      end
 
       raise 'You must specify a datastore for vCloud instances!' unless @options['datastore']
       raise 'You must specify a folder for vCloud instances!' unless @options['folder']

--- a/lib/beaker/hypervisor/vcloud.rb
+++ b/lib/beaker/hypervisor/vcloud.rb
@@ -17,7 +17,6 @@ module Beaker
       end
     end
 
-
     def initialize(vcloud_hosts, options)
       @options = options
       @logger = options[:logger]

--- a/lib/beaker/hypervisor/vcloud.rb
+++ b/lib/beaker/hypervisor/vcloud.rb
@@ -6,18 +6,16 @@ require 'rbvmomi'
 module Beaker
   class Vcloud < Beaker::Hypervisor
 
-    def self.new(vcloud_hosts, options)
-      if options['pooling_api']
-        Beaker::Vmpooler.new(vcloud_hosts, options)
-      else
-        super
-      end
-    end
-
     def initialize(vcloud_hosts, options)
       @options = options
       @logger = options[:logger]
       @hosts = vcloud_hosts
+
+      # Deprecation warning for pre-vmpooler style hosts configuration.
+      if options['pooling_api'] && !options['datacenter']
+        @logger.warn "It looks like you may be trying to access vmpooler with `hypervisor: vcloud`."
+        @logger.warn "This functionality has been deprecated. Please use `hypervisor: vmpooler`."
+      end
 
       raise 'You must specify a datastore for vCloud instances!' unless @options['datastore']
       raise 'You must specify a folder for vCloud instances!' unless @options['folder']

--- a/spec/beaker/hypervisor/vcloud_spec.rb
+++ b/spec/beaker/hypervisor/vcloud_spec.rb
@@ -18,11 +18,18 @@ module Beaker
 
     describe "#provision" do
 
-      it 'instantiates vmpooler if pooling api is provided' do
+      it 'warns about deprecated behavior if pooling_api is provided' do
         opts = make_opts
         opts[:pooling_api] = 'testpool'
+        expect( opts[:logger] ).to receive(:warn).twice
+        expect{ hypervisor = Beaker::Vcloud.new( make_hosts, opts) }.to raise_exception
+      end
+      it 'instantiates self even if pooling_api is provided' do
+        opts = make_opts
+        opts[:pooling_api] = 'testpool'
+        opts[:datacenter] = 'testdatacenter'
         hypervisor = Beaker::Vcloud.new( make_hosts, opts)
-        expect( hypervisor.class ).to be Beaker::Vmpooler
+        expect( hypervisor.class ).to be Beaker::Vcloud
       end
 
       it 'provisions hosts and add them to the pool' do

--- a/spec/beaker/hypervisor/vcloud_spec.rb
+++ b/spec/beaker/hypervisor/vcloud_spec.rb
@@ -18,13 +18,22 @@ module Beaker
 
     describe "#provision" do
 
-      it 'warns about deprecated behavior if pooling_api is provided' do
+      it 'warns about deprecated behavior if pooling_api and not datacenter is provided' do
         opts = make_opts
         opts[:pooling_api] = 'testpool'
-        expect( opts[:logger] ).to receive(:warn).twice
-        expect{ hypervisor = Beaker::Vcloud.new( make_hosts, opts) }.to raise_exception
+        # this shim taken from vmpooler_spec.rb
+        allow_any_instance_of( Beaker::Vmpooler ).to \
+          receive(:load_credentials).and_return(fog_file_contents)
+        expect( opts[:logger] ).to receive(:warn).once
+        Beaker::Vcloud.new( make_hosts, opts)
       end
-      it 'instantiates self even if pooling_api is provided' do
+      it 'instantiates vmpooler if pooling_api and not datacenter is provided' do
+        opts = make_opts
+        opts[:pooling_api] = 'testpool'
+        hypervisor = Beaker::Vcloud.new( make_hosts, opts)
+        expect( hypervisor.class ).to be Beaker::Vmpooler
+      end
+      it 'instantiates self if datacenter is provided' do
         opts = make_opts
         opts[:pooling_api] = 'testpool'
         opts[:datacenter] = 'testdatacenter'

--- a/spec/beaker/hypervisor/vcloud_spec.rb
+++ b/spec/beaker/hypervisor/vcloud_spec.rb
@@ -23,14 +23,14 @@ module Beaker
         opts[:pooling_api] = 'testpool'
         # this shim taken from vmpooler_spec.rb
         allow_any_instance_of( Beaker::Vmpooler ).to \
-          receive(:load_credentials).and_return(fog_file_contents)
-        expect( opts[:logger] ).to receive(:warn).once
-        Beaker::Vcloud.new( make_hosts, opts)
+          receive( :load_credentials ).and_return( fog_file_contents )
+        expect( opts[:logger] ).to receive( :warn ).once
+        Beaker::Vcloud.new( make_hosts, opts )
       end
       it 'instantiates vmpooler if pooling_api and not datacenter is provided' do
         opts = make_opts
         opts[:pooling_api] = 'testpool'
-        hypervisor = Beaker::Vcloud.new( make_hosts, opts)
+        hypervisor = Beaker::Vcloud.new( make_hosts, opts )
         expect( hypervisor.class ).to be Beaker::Vmpooler
       end
       it 'instantiates self if datacenter is provided' do


### PR DESCRIPTION
Deprecates an historical convenience option to allow vmpooler hosts to be accessed transparently using vcloud.