### PR TITLE
(BKR-1507) Specify vcenter_instance for init

### DIFF
--- a/lib/beaker/hypervisor/vcloud.rb
+++ b/lib/beaker/hypervisor/vcloud.rb
@@ -25,14 +25,16 @@ module Beaker
       raise 'You must specify a datastore for vCloud instances!' unless @options['datastore']
       raise 'You must specify a folder for vCloud instances!' unless @options['folder']
       raise 'You must specify a datacenter for vCloud instances!' unless @options['datacenter']
-      @vsphere_credentials = VsphereHelper.load_config(@options[:dot_fog])
+      @vcenter_credentials = get_fog_credentials(@options[:dot_fog], @options[:vcenter_instance] || :default)
     end
 
     def connect_to_vsphere
-      @logger.notify "Connecting to vSphere at #{@vsphere_credentials[:server]}" +
-        " with credentials for #{@vsphere_credentials[:user]}"
+      @logger.notify "Connecting to vSphere at #{@vcenter_credentials[:vsphere_server]}" +
+        " with credentials for #{@vcenter_credentials[:vsphere_username]}"
 
-      @vsphere_helper = VsphereHelper.new( @vsphere_credentials )
+      @vsphere_helper = VsphereHelper.new :server => @vcenter_credentials[:vsphere_server],
+                                          :user   => @vcenter_credentials[:vsphere_username],
+                                          :pass   => @vcenter_credentials[:vsphere_password]
     end
 
     def wait_for_dns_resolution host, try, attempts

--- a/spec/beaker/hypervisor/vcloud_spec.rb
+++ b/spec/beaker/hypervisor/vcloud_spec.rb
@@ -6,14 +6,16 @@ module Beaker
     before :each do
       MockVsphereHelper.set_config( fog_file_contents )
       MockVsphereHelper.set_vms( make_hosts() )
-     stub_const( "VsphereHelper", MockVsphereHelper )
-     stub_const( "Net", MockNet )
+      stub_const( "VsphereHelper", MockVsphereHelper )
+      stub_const( "Net", MockNet )
       json = double( 'json' )
       allow( json ).to receive( :parse ) do |arg|
         arg
       end
-     stub_const( "JSON", json )
+      stub_const( "JSON", json )
       allow( Socket ).to receive( :getaddrinfo ).and_return( true )
+      allow_any_instance_of( Beaker::Shared ).to receive( :get_fog_credentials ).and_return( fog_file_contents )
+      allow_any_instance_of( VsphereHelper ).to receive( :new ).and_return (MockVsphereHelper)
     end
 
     describe "#provision" do


### PR DESCRIPTION
Allow alternative vcenter instance credentials to be used for the
connection to allow for acceptance testing away from the default
vcenter.