### PR TITLE
(BKR-1509) Removes vcloud legacy fallback to vmpooler

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,24 @@ In previous versions of this hypervisor, a shim was added to ease internal trans
 
 This is a gem that allows you to use hosts of vcloud hypervisor with [beaker](https://github.com/puppetlabs/beaker).
 
-### Right Now? (beaker 3.x)
+Beaker will automatically load the appropriate hypervisors for any given hosts file, so as long as your project dependencies are satisfied there's nothing else to do. No need to `require` this library in your tests.
 
-This gem is already included as [beaker dependency](https://github.com/puppetlabs/beaker/blob/master/beaker.gemspec) for you, so you don't need to do anything special to use this gem's functionality with beaker.
+## With Beaker 3.x
 
-### In beaker's Next Major Version? (beaker 4.x)
+This library is included as a dependency of Beaker 3.x versions, so there's nothing to do.
 
-In beaker's next major version, the requirement for beaker-vcloud will be pulled
-from that repo. When that happens, then the usage pattern will change. In order
-to use this then, you'll need to include beaker-vcloud as a dependency right
-next to beaker itself.
+## With Beaker 4.x
+
+As of Beaker 4.0, all hypervisor and DSL extension libraries have been removed and are no longer dependencies. In order to use a specific hypervisor or DSL extension library in your project, you will need to include them alongside Beaker in your Gemfile or project.gemspec. E.g.
+
+~~~ruby
+# Gemfile
+gem 'beaker', '~>4.0'
+gem 'beaker-vcloud'
+# project.gemspec
+s.add_runtime_dependency 'beaker', '~>4.0'
+s.add_runtime_dependency 'beaker-vcloud'
+~~~
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 Beaker library to use vcloud hypervisor
 
+# Legacy VMPooler Fallback
+
+In previous versions of this hypervisor, a shim was added to ease internal transition to a new hypervisor called vmpooler. This shim would automatically and silently promote hosts with `hypervisor: vcloud` to use the beaker-vmpooler hypervisor if certain conditions were met: the hosts file contained a `CONFIG[:pooling_api]` and not the otherwise required `:datacenter`. This fallback behavior is no longer supported; if applicable, you will see a warning message with upgrade instructions.
+
 # How to use this wizardry
 
-This is a gem that allows you to use hosts of vcloud hypervisor with [beaker](https://github.com/puppetlabs/beaker). One thing to note is that if you are using a `pooling api` in your hosts file, beaker-vcloud will automatically switch to [beaker-vmpooler](https://github.com/puppetlabs/beaker-vmpooler). 
+This is a gem that allows you to use hosts of vcloud hypervisor with [beaker](https://github.com/puppetlabs/beaker).
 
 ### Right Now? (beaker 3.x)
 

--- a/beaker-vcloud.gemspec
+++ b/beaker-vcloud.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |s|
   # Run time dependencies
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
   s.add_runtime_dependency 'rbvmomi', '~> 1.9'
-  s.add_runtime_dependency 'beaker-vmpooler'
   s.add_runtime_dependency 'beaker-vmware'
 
 end

--- a/lib/beaker/hypervisor/vcloud.rb
+++ b/lib/beaker/hypervisor/vcloud.rb
@@ -1,5 +1,4 @@
 require 'yaml' unless defined?(YAML)
-require 'beaker/hypervisor/vmpooler'
 require 'beaker/hypervisor/vsphere_helper'
 require 'rbvmomi'
 
@@ -7,14 +6,13 @@ module Beaker
   class Vcloud < Beaker::Hypervisor
 
     def self.new(vcloud_hosts, options)
-      # Deprecation warning for pre-vmpooler style hosts configuration.
+      # Warning for pre-vmpooler style hosts configuration. TODO: remove this eventually.
       if options['pooling_api'] && !options['datacenter']
         options[:logger].warn "It looks like you may be trying to access vmpooler with `hypervisor: vcloud`. "\
-                              "This functionality has been deprecated. Please transition to `hypervisor: vmpooler`."
-        Beaker::Vmpooler.new(vcloud_hosts, options)
-      else
-        super
+                              "This functionality has been removed. Change your hosts to `hypervisor: vmpooler` "\
+                              "and remove unused :datacenter, :folder, and :datastore from CONFIG."
       end
+      super
     end
 
     def initialize(vcloud_hosts, options)

--- a/spec/beaker/hypervisor/vcloud_spec.rb
+++ b/spec/beaker/hypervisor/vcloud_spec.rb
@@ -20,22 +20,20 @@ module Beaker
 
     describe "#provision" do
 
-      it 'warns about deprecated behavior if pooling_api and not datacenter is provided' do
+      it 'warns about deprecated behavior if pooling_api is provided' do
         opts = make_opts
         opts[:pooling_api] = 'testpool'
-        # this shim taken from vmpooler_spec.rb
-        allow_any_instance_of( Beaker::Vmpooler ).to \
-          receive( :load_credentials ).and_return( fog_file_contents )
         expect( opts[:logger] ).to receive( :warn ).once
-        Beaker::Vcloud.new( make_hosts, opts )
+        expect{ Beaker::Vcloud.new( make_hosts, opts ) }.to raise_error( /datacenter/ )
       end
-      it 'instantiates vmpooler if pooling_api and not datacenter is provided' do
+
+      it 'does not instantiate vmpooler if pooling_api is provided' do
         opts = make_opts
         opts[:pooling_api] = 'testpool'
-        hypervisor = Beaker::Vcloud.new( make_hosts, opts )
-        expect( hypervisor.class ).to be Beaker::Vmpooler
+        expect{ Beaker::Vcloud.new( make_hosts, opts ) }.to raise_error( /datacenter/ )
       end
-      it 'instantiates self if datacenter is provided' do
+
+      it 'ignores pooling_api and instantiates self' do
         opts = make_opts
         opts[:pooling_api] = 'testpool'
         opts[:datacenter] = 'testdatacenter'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,7 @@
 require 'simplecov'
 require 'rspec/its'
 require 'beaker'
-require 'beaker/hypervisor/vmpooler'
-
-Dir.glob(Dir.pwd + '/lib/beaker/hypervisor/*.rb') {|file| require file}
+require 'beaker/hypervisor/vcloud'
 
 # setup & require beaker's spec_helper.rb
 beaker_gem_spec = Gem::Specification.find_by_name('beaker')


### PR DESCRIPTION
Retains the deprecation warning and adds upgrade instructions. This is a breaking change for users with legacy hosts configurations.